### PR TITLE
Fixed left margin width so that the logo doesn't exceed the margin on Firefox

### DIFF
--- a/html/general.css
+++ b/html/general.css
@@ -11,8 +11,7 @@ body {
 	font-size:   13px;
 }
 
-#logo:link, #logo:visited {
-	background-color: #fff;
+#logo a:link, #logo a:visited {
 	color:            #000;
 	font-family:      sans-serif;
 	font-size:        80px;
@@ -26,8 +25,16 @@ body {
 	top:              -1px;
 }
 
+#logo {
+    	background-color: #fff;
+}
+
 #logo:hover {
 	background-color: #000;
+	
+}
+
+#logo:hover a {
 	color:            #fff;
 }
 
@@ -41,7 +48,7 @@ div#left-margin {
 /* Add 1px to width for firefox */
 @-moz-document url-prefix() {
 	div#left-margin {
-		width:       164px;
+		width:       191px;
 	}
 }
 

--- a/html/general.css
+++ b/html/general.css
@@ -11,7 +11,7 @@ body {
 	font-size:   13px;
 }
 
-a#logo:link, a#logo:visited {
+#logo:link, #logo:visited {
 	background-color: #fff;
 	color:            #000;
 	font-family:      sans-serif;
@@ -26,7 +26,7 @@ a#logo:link, a#logo:visited {
 	top:              -1px;
 }
 
-a#logo:hover {
+#logo:hover {
 	background-color: #000;
 	color:            #fff;
 }

--- a/html/general.css
+++ b/html/general.css
@@ -45,10 +45,13 @@ div#left-margin {
 	width:            163px;
 }
 
-/* Add 1px to width for firefox */
+/* Fix for firefox */
 @-moz-document url-prefix() {
 	div#left-margin {
-		width:       191px;
+		width:       164px;
+	}
+	#logo a {
+		font-size:	 70px !important;
 	}
 }
 

--- a/html/header.html
+++ b/html/header.html
@@ -6,7 +6,7 @@
 	</head>
 	<body>
 		<div id="left-margin">
-			<a id="logo" href="?">cslug</a>
+			<div id="logo"><a href="?">cslug</a></div>
 			<ul id="navigation">
 				<li><a class="navigation" href="?">about/news</a></li>
 				<li><a class="navigation" href="?members">members</a></li>


### PR DESCRIPTION
This works better on FF and chrome, haven't tried other browsers though. The div element allows the logo to stay contained within a box as the left-margin width grows.
